### PR TITLE
Fix runtime errors on develop

### DIFF
--- a/src/main/java/frc/robot/shuffleboard/GRTNetworkTableEntry.java
+++ b/src/main/java/frc/robot/shuffleboard/GRTNetworkTableEntry.java
@@ -33,13 +33,12 @@ public class GRTNetworkTableEntry {
     public void update() {
         switch (this.type) {
             case GET:
-                buffer = tableEntry.getValue();
+                buffer = tableEntry.getValue().getValue();
                 break;
             case SET:
                 tableEntry.setValue(buffer);
                 break;
-        }
-        ;
+        };
     }
 
     public Object getValue() {

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -99,7 +99,7 @@ public class TurretSubsystem extends GRTSubsystem {
     // TODO: measure these, add constants
     private double theta;
     private double r;
-    private Pose2d previousPosition;
+    private Pose2d previousPosition = new Pose2d();
 
     private double desiredFlywheelSpeed = 30.0;
     private double desiredTurntablePosition = 0.0;


### PR DESCRIPTION
### Fixes:
- `ClassCastException` when attempting to use `GRTNetworkTableEntry.getValue()` -- it was returning a `NetworkTableValue` instance instead of the `Object` value
- `NullPointerException` in `TurretSubsystem.periodic()` after robot initialization -- this was an oversight with when jetson was non-null and it was attempting to calculate the hub location from `previousPosition` which was initialized to `null`